### PR TITLE
fix possible typos

### DIFF
--- a/src/lib/delete.js
+++ b/src/lib/delete.js
@@ -5,7 +5,7 @@ import * as u from '../util'
  * Delete content to an archive.
  * @promise Delete
  * @param archive {string} Path to the archive.
- * @param files {string|array} Files to add.
+ * @param files {string|array} Files to delete.
  * @param options {Object} An object of acceptable options to 7za bin.
  * @resolve {array} Arguments passed to the child-process.
  * @reject {Error} The error as issued by 7-Zip.

--- a/src/lib/update.js
+++ b/src/lib/update.js
@@ -6,7 +6,7 @@ import * as u from '../util'
  * Update content to an archive.
  * @promise Update
  * @param archive {string} Path to the archive.
- * @param files {string} Files to add.
+ * @param files {string} Files to update.
  * @param options {Object} An object of acceptables options to 7z bin.
  * @resolve {array} Arguments passed to the child-process.
  * @progress {array} Listed files and directories.


### PR DESCRIPTION
Fix two typos in function api doc (missed in copying?), not a big deal though.